### PR TITLE
CIPR-976: add AS&D url configuration

### DIFF
--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -157,6 +157,11 @@ type AppConfig {
   Configurations related to DataHub tests
   """
   testsConfig: TestsConfig!
+
+  """
+  Configurations related to ASD
+  """
+  asdConfig: ASDConfig!
 }
 
 """
@@ -304,4 +309,14 @@ type TestsConfig {
   Whether Tests feature is enabled
   """
   enabled: Boolean!
+}
+
+"""
+Configurations related to ASD
+"""
+type ASDConfig {
+  """
+  Url to ASD
+  """
+  url: String
 }

--- a/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
+++ b/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
@@ -55,11 +55,12 @@ export function AdminHeaderLinks(props: Props) {
     const showDomains = me?.platformPrivileges?.manageDomains || false;
     const showGlossary = me?.platformPrivileges?.manageGlossaries || false;
     const showASD = true;
+    const asdLink = config?.asd.url;
 
     return (
         <LinksWrapper areLinksHidden={areLinksHidden}>
             {showASD && (
-                <a href="/">
+                <a href={asdLink}>
                     <Button type="text">Go to Advanced Search and Dashboards</Button>
                 </a>
             )}

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -31,6 +31,9 @@ export const DEFAULT_APP_CONFIG = {
     testsConfig: {
         enabled: false,
     },
+    asdConfig: {
+        url: "/"
+    }
 };
 
 export const AppConfigContext = React.createContext<{

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -91,6 +91,9 @@ visualConfig:
   assets:
     logoUrl: ${REACT_APP_LOGO_URL:/assets/platforms/datahublogo.png}
 
+asdConfig:
+  url: ${ASD_URL:http://localhost:8088}
+
 # Storage Layer
 
 # Only required if entityService.impl is ebean


### PR DESCRIPTION
Needed to pass the AS&D new domain to the header link, hence these changes.